### PR TITLE
Added support for renamed commands.

### DIFF
--- a/click_web/resources/index.py
+++ b/click_web/resources/index.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Union
+from typing import Tuple, Union
 
 import click
 from flask import render_template
@@ -12,32 +12,41 @@ def index():
         return render_template('show_tree.html.j2', ctx=ctx, tree=_click_to_tree(ctx, click_web.click_root_cmd))
 
 
-def _click_to_tree(ctx: click.Context, node: Union[click.Command, click.MultiCommand], ancestors: list = None):
+def _click_to_tree(
+    ctx: click.Context,
+    node: Union[click.Command, click.MultiCommand],
+    name: str | None = None,
+    ancestors: list[Tuple[str, click.Command | click.MultiCommand]] | None = None,
+):
     """
     Convert a click root command to a tree of dicts and lists
     :return: a json like tree
     """
     if ancestors is None:
         ancestors = []
+    if name is None:
+        name = node.name
+
     res_childs = []
     res = OrderedDict()
     res['is_group'] = isinstance(node, click.core.MultiCommand)
     if res['is_group']:
         # a group, recurse for every child
-        children = [node.get_command(ctx, key) for key in node.list_commands(ctx)]
+        children = [(child_name, node.get_command(ctx, child_name)) for child_name in node.list_commands(ctx)]
         # Sort so commands comes before groups
-        children = sorted(children, key=lambda c: isinstance(c, click.core.MultiCommand))
-        for child in children:
-            res_childs.append(_click_to_tree(ctx, child, ancestors[:] + [node, ]))
+        children = sorted(children, key=lambda c: isinstance(c[1], click.core.MultiCommand))
+        for child_name, child in children:
+            res_childs.append(_click_to_tree(ctx, child, child_name, ancestors[:] + [(name, node), ]))
 
-    res['name'] = node.name
+    res['name'] = name
 
     # Do not include any preformatted block (\b) for the short help.
     res['short_help'] = node.get_short_help_str().split('\b')[0]
     res['help'] = node.help
-    path_parts = ancestors + [node]
+    path_parts = ancestors + [(name, node)]
     root = click_web._flask_app.config['APPLICATION_ROOT'].rstrip('/')
-    res['path'] = root + '/' + '/'.join(p.name for p in path_parts)
+    # Join names to build path.
+    res['path'] = root + '/' + '/'.join(p[0] for p in path_parts)
     if res_childs:
         res['childs'] = res_childs
     return res

--- a/click_web/templates/command_form.html.j2
+++ b/click_web/templates/command_form.html.j2
@@ -1,6 +1,6 @@
 {% import 'form_macros.html.j2' as macros %}
-<div class="command-title-parents">{{ levels[1:-1]| join(' - ', attribute='command.name')|title }}</div>
-<h1 class="command-title">{{ command.name|title }}</h1>
+<div class="command-title-parents">{{ levels[1:-1]| join(' - ', attribute='command_name')|title }}</div>
+<h1 class="command-title">{{ command_name|title }}</h1>
 <div class="command-help">{{ command.html_help }}</div>
 
 <form id="inputform"
@@ -11,15 +11,15 @@
       enctype="multipart/form-data">
     {% set command_list = [] %}
     {% for level in levels %}
-        <fieldset name="{{ level.command.name }}">
+        <fieldset name="{{ level.command_name }}">
             {% if loop.index == 1 %}
                 {# do not print root command as it most likely is juse "cli" #}
                 <legend class="command-header"></legend>
             {% elif not level.fields %}
                 {# It is just a command group without any options do not create it's own section #}
-                {% do command_list.append(level.command.name) %}
+                {% do command_list.append(level.command_name) %}
             {% else %}
-                {% do command_list.append(level.command.name) %}
+                {% do command_list.append(level.command_name) %}
                 <legend class="command-header">{{ command_list | join('&ensp;') }}</legend>
                 {% do command_list.clear() %}
             {% endif %}

--- a/tests/fixtures/script/a_script.py
+++ b/tests/fixtures/script/a_script.py
@@ -14,6 +14,24 @@ def simple_no_params_command():
     click.echo("Simpel noparams command called")
 
 
+@click.command()
+def late_registered_simple_command():
+    'Help text'
+    click.echo("Late registered command called")
+
+
+cli.add_command(late_registered_simple_command)
+
+
+@click.command()
+def to_be_renamed_simple_command():
+    'Help text'
+    click.echo("Renamed simple command called")
+
+
+cli.add_command(to_be_renamed_simple_command, "renamed-simple-command")
+
+
 @cli.command()
 @click.option("--unicode-msg", type=click.Choice(['Åäö']), default='Åäö', required=True,
               help='Message with unicide chars to print.')

--- a/tests/test_click_web.py
+++ b/tests/test_click_web.py
@@ -30,7 +30,7 @@ def test_render_command_form(cli, loaded_script_module):
 
 
 @pytest.mark.parametrize(
-    'command_path, command_name, command_help',
+    'command_path, expected_command_name, command_help',
     [
         ('cli/command-with-option-and-argument', 'command-with-option-and-argument', 'Help text'),
         ('cli/late-registered-simple-command', 'late-registered-simple-command', 'Help text'),
@@ -41,12 +41,12 @@ def test_render_command_form(cli, loaded_script_module):
 def test_command_path(cli,
                       loaded_script_module,
                       command_path,
-                      command_name,
+                      expected_command_name,
                       command_help):
     click_web._register(loaded_script_module, cli)
-    ctx, command = click_web.resources.cmd_form._get_commands_by_path(command_path)[-1]
+    ctx, command, command_name = click_web.resources.cmd_form._get_commands_by_path(command_path)[-1]
 
-    assert command.name == command_name
+    assert command_name == expected_command_name
     assert command.help == command_help
 
 

--- a/tests/test_click_web.py
+++ b/tests/test_click_web.py
@@ -33,6 +33,8 @@ def test_render_command_form(cli, loaded_script_module):
     'command_path, command_name, command_help',
     [
         ('cli/command-with-option-and-argument', 'command-with-option-and-argument', 'Help text'),
+        ('cli/late-registered-simple-command', 'late-registered-simple-command', 'Help text'),
+        ('cli/renamed-simple-command', 'renamed-simple-command', 'Help text'),
         ('cli/sub-group', 'sub-group', 'a sub group'),
         ('cli/sub-group/a-sub-group-command', 'a-sub-group-command', 'Help for sub_group.sub_group_command '),
     ])

--- a/tests/test_flask_get.py
+++ b/tests/test_flask_get.py
@@ -17,6 +17,16 @@ def test_get_index(app, client):
              '0.0.flag.bool_flag.1.checkbox.--debug'
          ]),
 
+        ('/cli/late-registered-simple-command', 200, b'>Late-Registered-Simple-Command</',
+         [
+             '0.0.flag.bool_flag.1.checkbox.--debug'
+         ]),
+
+        ('/cli/renamed-simple-command', 200, b'>Renamed-Simple-Command</',
+         [
+             '0.0.flag.bool_flag.1.checkbox.--debug'
+         ]),
+
         ('/cli/unicode-test', 200, 'Åäö'.encode('utf-8'),
          [
              '0.0.flag.bool_flag.1.checkbox.--debug',

--- a/tests/test_flask_get.py
+++ b/tests/test_flask_get.py
@@ -6,6 +6,8 @@ def test_get_index(app, client):
     resp = client.get('/')
     assert resp.status_code == 200
     assert b'the root command' in resp.data
+    assert b'renamed-simple-command' in resp.data
+    assert b'to-be-renamed-simple-command' not in resp.data
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flask_post.py
+++ b/tests/test_flask_post.py
@@ -8,6 +8,18 @@ def test_exec_command(app, client):
     assert b'Simpel noparams command called' in resp.data
 
 
+def test_exec_late_registered_command(app, client):
+    resp = client.post('/cli/late-registered-simple-command')
+    assert resp.status_code == 200
+    assert b'Late registered command called' in resp.data
+
+
+def test_exec_renamed_command(app, client):
+    resp = client.post('/cli/renamed-simple-command')
+    assert resp.status_code == 200
+    assert b'Renamed simple command called' in resp.data
+
+
 def test_exec_sub_command(app, client):
     resp = client.post('/cli/sub-group/a-sub-group-command')
     assert resp.status_code == 200


### PR DESCRIPTION
In the latest version of click, [commands can be added to groups with a custom name.](https://click.palletsprojects.com/en/8.1.x/api/#click.Group.add_command) The current version of this library doesn't handle this mismatch, and so will fail for these commands.

Added tests to replicate these issues and then fixed the indexer and path resolver to handle renames.